### PR TITLE
GH#137 / GH#138: Fix frontend `Something went wrong: Failed to split_once header`

### DIFF
--- a/src/serve/frontend.rs
+++ b/src/serve/frontend.rs
@@ -259,6 +259,9 @@ async fn get_pan_thunder_com(
         if header.is_empty() {
             break;
         }
+        if header.starts_with("getEnvs ") {
+            continue;
+        }
 
         let (header, val) = header
             .split_once(':')


### PR DESCRIPTION
## TL;DR: 迅雷新版本 `v3.19.2` 导致前端报错：

`Something went wrong: Failed to split_once header`

https://github.com/gngpp/thunder/blob/main/src/serve/frontend.rs#L263-L266

使用deb包安装无法使用
https://github.com/gngpp/thunder/issues/137

编译安装有问题，无法正常编译，并且deb安装也无法使用
https://github.com/gngpp/thunder/issues/138

```diff
diff --git a/src/serve/frontend.rs b/src/serve/frontend.rs
index 4ceaccd..18cd474 100644
--- a/src/serve/frontend.rs
+++ b/src/serve/frontend.rs
@@ -260,6 +260,8 @@ async fn get_pan_thunder_com(
             break;
         }
 
+        println!(">>> {:?}", header);
+        log::warn!(">>> {:?}", header);
         let (header, val) = header
             .split_once(':')
             .context("Failed to split_once header")?;
```

```bash
$ docker logs xunlei_xunlei_1 | grep "^>>>" | sort -Vu
>>> "getEnvs succ DownloadPATH=/xunlei/downloads"
```

```diff
diff --git a/src/serve/frontend.rs b/src/serve/frontend.rs
index 4ceaccd..91c1589 100644
--- a/src/serve/frontend.rs
+++ b/src/serve/frontend.rs
@@ -260,6 +260,12 @@ async fn get_pan_thunder_com(
             break;
         }
 
+        println!(">>> {:?}", header);
+        log::warn!(">>> {:?}", header);
+        if header.starts_with("getEnvs ") {
+            continue;
+        }
+
         let (header, val) = header
             .split_once(':')
             .context("Failed to split_once header")?;
```

```
...
>>> "getEnvs succ ConfigPath=/xunlei/config"
>>> "getEnvs succ DownloadPATH=/xunlei/downloads"
>>> "getEnvs succ DriveListen=unix:///var/packages/pan-xunlei-com/target/var/pan-xunlei-com.sock"
```

## Final solution

```diff
diff --git a/src/serve/frontend.rs b/src/serve/frontend.rs
index 4ceaccd..0ff38f0 100644
--- a/src/serve/frontend.rs
+++ b/src/serve/frontend.rs
@@ -259,6 +259,9 @@ async fn get_pan_thunder_com(
         if header.is_empty() {
             break;
         }
+        if header.starts_with("getEnvs ") {
+            continue;
+        }
 
         let (header, val) = header
             .split_once(':')
```